### PR TITLE
decoder: recurse structures, not form values

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -5,7 +5,6 @@ import (
 	"net/url"
 	"reflect"
 	"strconv"
-	"strings"
 	"time"
 )
 
@@ -30,6 +29,12 @@ func (h *HTTPDecoder) Decode(data interface{}) error {
 		panic("formulate: decode target must be pointer")
 	}
 
+	elem := val.Elem()
+
+	if elem.Kind() != reflect.Struct {
+		panic("formulate: decode target underlying value must be struct")
+	}
+
 	if decoder, ok := data.(CustomDecoder); ok {
 		data, err := decoder.DecodeFormValue(h.form, "", nil)
 
@@ -41,163 +46,166 @@ func (h *HTTPDecoder) Decode(data interface{}) error {
 			data = data.Elem()
 		}
 
-		val.Elem().Set(data)
+		elem.Set(data)
 
 		return nil
 	}
 
-	urlValues := make(url.Values)
-	v := reflect.ValueOf(data).Elem()
-
-	err := h.recurse(v, v.Type().String(), &urlValues)
-
-	if err != nil {
-		return err
-	}
-
-	for name, vals := range h.form {
-		urlValues[name] = vals
-	}
-
-	for name, vals := range urlValues {
-		if err := h.assignFieldValues(val.Elem(), name, vals); err != nil {
-			return err
-		}
-	}
-
-	return nil
+	return h.decode(elem, elem.Type().String())
 }
 
-func (h *HTTPDecoder) recurse(v reflect.Value, key string, urlValues *url.Values) error {
-	switch v.Interface().(type) {
-	case time.Time, Select, RadioList, CustomEncoder:
-		name := formElementName(key)
-		urlValues.Set(name, "")
+func (h *HTTPDecoder) getFormValues(key string) []string {
+	key = formElementName(key)
 
-		return nil
+	var vals []string
+
+	if formValues, ok := h.form[key]; ok {
+		vals = formValues
 	}
 
-	switch v.Kind() {
-	case reflect.Ptr:
-		if v.IsNil() && v.CanAddr() {
-			v.Set(reflect.New(v.Type().Elem()))
-		}
+	return vals
+}
 
-		return h.recurse(v.Elem(), key, urlValues)
+func (h *HTTPDecoder) decode(val reflect.Value, key string) error {
+	if val.CanInterface() {
+		switch a := val.Interface().(type) {
+		case CustomDecoder:
+			decodedFormVal, err := a.DecodeFormValue(h.form, key, h.getFormValues(key))
+
+			if err != nil {
+				return err
+			}
+
+			if !decodedFormVal.IsValid() {
+				return nil
+			}
+
+			/*if val.IsNil() && val.CanAddr() {
+				val.Set(reflect.New(decodedFormVal.Type()))
+			}*/
+
+			val.Set(decodedFormVal)
+
+			return nil
+		case time.Time:
+			values := h.getFormValues(key)
+
+			var t time.Time
+
+			if len(values) > 0 {
+				var err error
+
+				t, err = time.Parse(timeFormat, values[0])
+
+				if err != nil {
+					return err
+				}
+			}
+
+			val.Set(reflect.ValueOf(t))
+
+			return nil
+		}
+	}
+
+	values := h.getFormValues(key)
+
+	var formValue string
+
+	if len(values) > 0 {
+		formValue = values[0]
+	}
+
+	switch val.Kind() {
 	case reflect.Struct:
-		for i := 0; i < v.NumField(); i++ {
-			err := h.recurse(v.Field(i), key+fieldSeparator+v.Type().Field(i).Name, urlValues)
+		// recurse over the fields
+		for i := 0; i < val.NumField(); i++ {
+			field := val.Field(i)
+			fieldType := val.Type().Field(i)
+
+			err := h.decode(field, key+fieldSeparator+fieldType.Name)
 
 			if err != nil {
 				return err
 			}
 		}
 		return nil
-	default:
-		name := formElementName(key)
-		urlValues.Set(name, "")
-
-		return nil
-	}
-}
-
-const fieldSeparator = "."
-
-func (h *HTTPDecoder) assignFieldValues(val reflect.Value, formName string, formValues []string) error {
-	parts := strings.Split(formName, fieldSeparator)
-	field := val.FieldByName(parts[0])
-
-	if !field.CanSet() || len(formValues) == 0 {
-		return nil
-	}
-
-	formValue := formValues[0]
-
-	switch a := field.Interface().(type) {
-	case CustomDecoder:
-		val, err := a.DecodeFormValue(h.form, formName, formValues)
-
-		if err != nil {
-			return err
+	case reflect.Ptr:
+		// dereference ptr, decode again
+		if val.IsNil() && val.CanAddr() {
+			val.Set(reflect.New(val.Type().Elem()))
 		}
 
-		field.Set(val)
-
-		return nil
-	case time.Time:
-		t, err := time.Parse(timeFormat, formValue)
-
-		if err != nil {
-			return err
-		}
-
-		field.Set(reflect.ValueOf(t))
-
-		return nil
-	}
-
-	if field.Kind() == reflect.Ptr {
-		if field.IsNil() {
-			v := reflect.New(field.Type().Elem())
-
-			field.Set(v)
-		}
-
-		field = field.Elem()
-	}
-
-	switch field.Kind() {
-	case reflect.Struct:
-		return h.assignFieldValues(field, strings.Join(parts[1:], fieldSeparator), formValues)
+		return h.decode(val.Elem(), key)
 	case reflect.String:
-		field.SetString(formValue)
+		val.SetString(formValue)
 		return nil
 	case reflect.Float64, reflect.Float32:
-		i, err := strconv.ParseFloat(formValue, 64)
+		var f float64
+		var err error
 
-		if err != nil {
-			return err
+		if formValue != "" {
+			f, err = strconv.ParseFloat(formValue, 64)
+
+			if err != nil {
+				return err
+			}
 		}
 
-		field.SetFloat(i)
+		val.SetFloat(f)
 		return nil
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		i, err := strconv.ParseInt(formValue, 10, 0)
+		var i int64
+		var err error
 
-		if err != nil {
-			return err
+		if formValue != "" {
+			i, err = strconv.ParseInt(formValue, 10, 0)
+
+			if err != nil {
+				return err
+			}
 		}
 
-		field.SetInt(i)
+		val.SetInt(i)
 		return nil
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-		i, err := strconv.ParseUint(formValue, 10, 0)
+		var i uint64
+		var err error
 
-		if err != nil {
-			return err
+		if formValue != "" {
+			i, err = strconv.ParseUint(formValue, 10, 0)
+
+			if err != nil {
+				return err
+			}
 		}
 
-		field.SetUint(i)
+		val.SetUint(i)
 		return nil
 	case reflect.Bool:
 		if formValue == "on" {
-			field.SetBool(true)
+			val.SetBool(true)
 		} else {
-			i, err := strconv.ParseInt(formValue, 10, 0)
+			var i int64
+			var err error
 
-			if err != nil {
-				return err
+			if formValue != "" {
+				i, err = strconv.ParseInt(formValue, 10, 0)
+
+				if err != nil {
+					return err
+				}
 			}
 
-			field.SetBool(i == 1)
+			val.SetBool(i == 1)
 		}
 
 		return nil
 	case reflect.Map, reflect.Slice, reflect.Array:
-		i := reflect.New(field.Type())
+		i := reflect.New(val.Type())
 
 		if formValue == "" {
-			field.Set(i.Elem())
+			val.Set(i.Elem())
 			return nil
 		}
 
@@ -205,12 +213,9 @@ func (h *HTTPDecoder) assignFieldValues(val reflect.Value, formName string, form
 			return err
 		}
 
-		field.Set(i.Elem())
+		val.Set(i.Elem())
 		return nil
 	default:
-		// @TODO warning?
-		// panic("formulate: unknown kind: " + field.Kind().String())
+		return nil
 	}
-
-	return nil
 }

--- a/decode_test.go
+++ b/decode_test.go
@@ -2,6 +2,8 @@ package formulate
 
 import (
 	"net/url"
+	"reflect"
+	"strings"
 	"testing"
 	"time"
 )
@@ -12,25 +14,25 @@ func TestHttpDecoder_Decode(t *testing.T) {
 It spans multiple lines`
 
 	vals := url.Values{
-		"Name":                    {"John Smith"},
-		"Age":                     {"25"},
-		"Email":                   {"john.smith@example.com"},
-		"ConfirmedEmail":          {"on"},
-		"Description":             {description},
-		"Password":                {"hunter2"},
-		"Time":                    {"2020-05-28T15:28"},
-		"Pet":                     {"moose"},
-		"ContactMethod":           {"email"},
-		"Address.HouseName":       {"1 Example Road"},
-		"Address.AddressLine1":    {"Fake Town"},
-		"Address.AddressLine2":    {"Fake City"},
-		"Address.Postcode":        {"Postcode"},
-		"Address.TelephoneNumber": {"012345678910"},
-		"Address.Country":         {"UK"},
-		"EmbeddedStruct.Type":     {"4838374"},
-		"TestMap":                 {`{"Foo": "Banana", "baz": "chocolate"}`},
-		"FavouriteNumber":         {"1.222"},
-		"FavouriteFoods":          {"burger", "pizza", "beans"},
+		"Name":                                   {"John Smith"},
+		"Age":                                    {"25"},
+		"Email":                                  {"john.smith@example.com"},
+		"ConfirmedEmail":                         {"on"},
+		"Description":                            {description},
+		"Password":                               {"hunter2"},
+		"Time":                                   {"2020-05-28T15:28"},
+		"Pet":                                    {"moose"},
+		"ContactMethod":                          {"email"},
+		joinFields("Address", "HouseName"):       {"1 Example Road"},
+		joinFields("Address", "AddressLine1"):    {"Fake Town"},
+		joinFields("Address", "AddressLine2"):    {"Fake City"},
+		joinFields("Address", "Postcode"):        {"Postcode"},
+		joinFields("Address", "TelephoneNumber"): {"012345678910"},
+		joinFields("Address", "Country"):         {"UK"},
+		joinFields("EmbeddedStruct", "Type"):     {"4838374"},
+		"TestMap":                                {`{"Foo": "Banana", "baz": "chocolate"}`},
+		"FavouriteNumber":                        {"1.222"},
+		"FavouriteFoods":                         {"burger", "pizza", "beans"},
 	}
 
 	details := YourDetails{EmbeddedStruct: EmbeddedStruct{SomeMultiselect: []string{"cake"}}}
@@ -59,6 +61,17 @@ It spans multiple lines`
 	assertEquals(t, details.FavouriteNumber, 1.222)
 	assertEquals(t, len(details.SomeMultiselect), 0)
 	assertEquals(t, len(details.FavouriteFoods), 3)
+	assertEquals(t, len(details.EmptySliceTest), 0)
+}
+
+type emptySlice []string
+
+func (e emptySlice) DecodeFormValue(form url.Values, name string, values []string) (reflect.Value, error) {
+	if len(values) == 0 {
+		return reflect.Value{}, nil
+	}
+
+	return reflect.ValueOf(emptySlice(values)), nil
 }
 
 func assertEquals(t *testing.T, a interface{}, b interface{}) {
@@ -68,4 +81,8 @@ func assertEquals(t *testing.T, a interface{}, b interface{}) {
 
 	t.Logf("failed to assert that '%v' == '%v'", a, b)
 	t.Fail()
+}
+
+func joinFields(fields ...string) string {
+	return strings.Join(fields, fieldSeparator)
 }

--- a/encode.go
+++ b/encode.go
@@ -670,6 +670,8 @@ func BuildRadioButtons(r RadioList, key string, field StructField, decorator Dec
 	return div
 }
 
+const fieldSeparator = "."
+
 func formElementName(label string) string {
 	return strings.Join(strings.Split(label, fieldSeparator)[2:], fieldSeparator)
 }

--- a/encode.go
+++ b/encode.go
@@ -16,13 +16,13 @@ import (
 
 // HTMLEncoder is used to generate a HTML form from a given struct.
 type HTMLEncoder struct {
+	showConditions
+
 	n *html.Node
 	w io.Writer
 
 	decorator Decorator
 	format    bool
-
-	showConditions map[string]ShowConditionFunc
 }
 
 // NewEncoder returns a HTMLEncoder which outputs to w. A Decorator can be passed to NewEncoder, which will then be used
@@ -43,7 +43,7 @@ func NewEncoder(w io.Writer, decorator Decorator) *HTMLEncoder {
 		w:              w,
 		n:              n,
 		decorator:      decorator,
-		showConditions: make(map[string]ShowConditionFunc),
+		showConditions: make(showConditions),
 	}
 }
 
@@ -51,24 +51,6 @@ func NewEncoder(w io.Writer, decorator Decorator) *HTMLEncoder {
 // Formatting is provided by the https://github.com/yosssi/gohtml package.
 func (h *HTMLEncoder) SetFormat(b bool) {
 	h.format = b
-}
-
-// ShowConditionFunc is a function which determines whether or not to show a form element. See: HTMLEncoder.AddShowCondition
-type ShowConditionFunc func() bool
-
-// AddShowCondition allows you to determine visibility of certain form elements.
-// For example, given the following struct:
-//   type Example struct {
-//     Name string
-//     SecretOption bool `show:"adminOnly"`
-//   }
-// If you wanted to make the SecretOption field only show to admins, you would call AddShowCondition as follows:
-//   AddShowCondition("adminOnly", func() bool {
-//      // some code that determines if we are 'admin'
-//   })
-// You can add multiple ShowConditions, but they must have different keys.
-func (h *HTMLEncoder) AddShowCondition(key string, fn ShowConditionFunc) {
-	h.showConditions[key] = fn
 }
 
 func errorIncorrectValue(t reflect.Type) error {
@@ -547,7 +529,7 @@ func BuildSelectField(s Select, key string, field StructField) *html.Node {
 		checked := false
 
 		if opt.Checked == nil {
-			checked = opt.Value == s
+			checked = toString(opt.Value) == toString(s)
 		} else {
 			checked = bool(*opt.Checked)
 		}

--- a/encode_test.go
+++ b/encode_test.go
@@ -91,6 +91,8 @@ type EmbeddedStruct struct {
 	Variable        string
 	Type            uint32
 	SomeMultiselect []string
+
+	EmptySliceTest emptySlice
 }
 
 type Pet string

--- a/field.go
+++ b/field.go
@@ -131,3 +131,24 @@ func (sf StructField) BuildFieldset() bool {
 
 	return !sf.StructField.Anonymous
 }
+
+// ShowConditionFunc is a function which determines whether or not to show a form element. See: HTMLEncoder.AddShowCondition
+type ShowConditionFunc func() bool
+
+type showConditions map[string]ShowConditionFunc
+
+// AddShowCondition allows you to determine visibility of certain form elements.
+// For example, given the following struct:
+//   type Example struct {
+//     Name string
+//     SecretOption bool `show:"adminOnly"`
+//   }
+// If you wanted to make the SecretOption field only show to admins, you would call AddShowCondition as follows:
+//   AddShowCondition("adminOnly", func() bool {
+//      // some code that determines if we are 'admin'
+//   })
+// You can add multiple ShowConditions, but they must have different keys.
+// Note: ShowConditions should be added to both the Encoder and Decoder.
+func (s showConditions) AddShowCondition(key string, fn ShowConditionFunc) {
+	s[key] = fn
+}


### PR DESCRIPTION
Decoding using purely form values can leave existing values in place for certain types. The existing solution in 3a844d66a01c4270d9ccdea54bce3ed59259b617 was an improvement to this scenario, but pre-filling all data points with empty keys could lead to slices with empty strings in them, when the intended result was a slice with no elements. The emptySlice test in decoder_test.go verifies that this issue has been resolved.