### PR TITLE
decoder: remove values from the form as they are decoded

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -146,7 +146,7 @@ func (h *HTMLEncoder) recurse(v reflect.Value, key string, field StructField, pa
 	if v.CanInterface() {
 		switch v.Interface().(type) {
 		case time.Time, Select, RadioList, CustomEncoder:
-			return BuildField(v, formElementName(key), field, parent, h.decorator, h.showConditions)
+			return BuildField(v, FormElementName(key), field, parent, h.decorator, h.showConditions)
 		}
 	}
 
@@ -174,7 +174,7 @@ func (h *HTMLEncoder) recurse(v reflect.Value, key string, field StructField, pa
 
 			nextKey := key + fieldSeparator + v.Type().Field(i).Name
 
-			validationErrors, err := h.validationStore.GetValidationErrors(formElementName(nextKey))
+			validationErrors, err := h.validationStore.GetValidationErrors(FormElementName(nextKey))
 
 			if err != nil {
 				return err
@@ -208,7 +208,7 @@ func (h *HTMLEncoder) recurse(v reflect.Value, key string, field StructField, pa
 
 		return h.recurse(reflect.ValueOf(Raw(buf.Bytes())), key, field, parent)
 	default:
-		return BuildField(v, formElementName(key), field, parent, h.decorator, h.showConditions)
+		return BuildField(v, FormElementName(key), field, parent, h.decorator, h.showConditions)
 	}
 }
 
@@ -763,8 +763,15 @@ func BuildRadioButtons(r RadioList, key string, field StructField, decorator Dec
 
 const fieldSeparator = "."
 
-func formElementName(label string) string {
-	return strings.Join(strings.Split(label, fieldSeparator)[2:], fieldSeparator)
+// FormElementName returns the name of the form element within the form, removing the package path and base struct name.
+func FormElementName(key string) string {
+	keySplit := strings.Split(key, fieldSeparator)
+
+	if len(keySplit) > 2 {
+		return strings.Join(keySplit[2:], fieldSeparator)
+	}
+
+	return key
 }
 
 func BuildLabel(label string, parent *html.Node, field StructField, decorator Decorator) {

--- a/types.go
+++ b/types.go
@@ -28,6 +28,10 @@ type CustomDecoder interface {
 	// and the values for that specific element. It must return a reflect.Value of equal type to the
 	// type which is implementing the CustomDecoder interface. If err != nil, the error will propagate
 	// back through to the Decode() call.
+	//
+	// By default, primitive types supported by formulate will remove the values from the form as the form is decoded.
+	// CustomDecoders may replicate this behaviour if needed, but formulate will not do it automatically.
+	// See PopFormValue and FormElementName for more information.
 	DecodeFormValue(form url.Values, name string, values []string) (reflect.Value, error)
 }
 
@@ -88,8 +92,8 @@ type RadioList interface {
 type BoolNumber int
 
 // DecodeFormValue implements the CustomDecoder interface.
-func (bn BoolNumber) DecodeFormValue(form url.Values, name string, values []string) (reflect.Value, error) {
-	val := values[0]
+func (bn BoolNumber) DecodeFormValue(form url.Values, name string, _ []string) (reflect.Value, error) {
+	val := PopFormValue(form, FormElementName(name))
 
 	if val == "on" || val == "1" {
 		return reflect.ValueOf(BoolNumber(1)), nil
@@ -99,8 +103,8 @@ func (bn BoolNumber) DecodeFormValue(form url.Values, name string, values []stri
 }
 
 // Bool returns true if the underlying value is 1.
-func (bn *BoolNumber) Bool() bool {
-	return *bn == 1
+func (bn BoolNumber) Bool() bool {
+	return bn == 1
 }
 
 // Raw is byte data which should be rendered as a string inside a textarea.


### PR DESCRIPTION
Removing values as they are decoded allows for decoding of multiple form elements with the same name without any extra considerations.

This feature also makes `FormElementName()` public, and adds `PopFormValue()`. These allow `CustomDecoders` to replicate this behaviour if they choose.

fixes #25 