### PR TITLE
encoding: adds improvements to show conditions, giving more control over when fields are rendered

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -10,7 +10,7 @@ import (
 
 // HTTPDecoder takes a set of url values and decodes them.
 type HTTPDecoder struct {
-	showConditions
+	ShowConditions
 
 	form url.Values
 
@@ -23,7 +23,7 @@ type HTTPDecoder struct {
 // NewDecoder creates a new HTTPDecoder.
 func NewDecoder(form url.Values) *HTTPDecoder {
 	return &HTTPDecoder{
-		showConditions: make(map[string]ShowConditionFunc),
+		ShowConditions: make(ShowConditions),
 		form:           form,
 
 		validators:                make(map[ValidatorKey]Validator),
@@ -198,7 +198,7 @@ func (h *HTTPDecoder) decode(val reflect.Value, key string, validators []Validat
 				continue
 			}
 
-			if structField.Hidden(h.showConditions) {
+			if structField.Hidden(h.ShowConditions) {
 				// hidden fields will not be in the form, so don't decode them.
 				continue
 			}

--- a/doc_test.go
+++ b/doc_test.go
@@ -105,6 +105,10 @@ func ExampleNewDecoder() {
 		Postcode        string
 		TelephoneNumber Tel
 		CountryCode     string `pattern:"[A-Za-z]{3}" validators:"countryCode"`
+
+		EmptyStruct struct {
+			Foo string `show:"-"`
+		}
 	}
 
 	// formValues - usually these would come from *http.Request.Form!

--- a/html.go
+++ b/html.go
@@ -9,7 +9,6 @@ import (
 
 // RenderHTMLToNode renders a html string into a parent *html.Node.
 // The parent node is emptied before the data is rendered into it.
-// The 'data' argument must be wrapped in a single HTML node, usually a <div>.
 func RenderHTMLToNode(data template.HTML, parent *html.Node) error {
 	n, err := html.Parse(strings.NewReader(string(data)))
 
@@ -23,10 +22,7 @@ func RenderHTMLToNode(data template.HTML, parent *html.Node) error {
 		parent.RemoveChild(c)
 	}
 
-	for c := body.FirstChild; c != nil; c = c.NextSibling {
-		body.RemoveChild(c)
-		parent.AppendChild(c)
-	}
+	moveNodeChildren(body, parent)
 
 	return nil
 }
@@ -48,4 +44,16 @@ func getBody(node *html.Node) *html.Node {
 	f(node)
 
 	return body
+}
+
+func moveNodeChildren(from, to *html.Node) {
+	c := from.FirstChild
+
+	for c != nil {
+		x := c
+		c = c.NextSibling
+
+		from.RemoveChild(x)
+		to.AppendChild(x)
+	}
 }


### PR DESCRIPTION
* It is now possible to add multiple show conditions for a single key. If multiple are specified, all must pass for the field to be shown
* ShowConditionFuncs are now passed the StructField, which can be used to make decisions about visibility
* Added new `AddGlobalShowCondition` method which visits all fields in a struct
* When encoding a HTML form, structs that result in no rendered children elements are not rendered nor decorated
* Improved RenderHTMLToNode to not require wrapping of children nodes in a <div>